### PR TITLE
Added ez-clasp, a rich support TypeScript starter kit

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,7 @@
 
 ### Starter Kits
 
+* [ez-clasp](https://github.com/cristobalgvera/ez-clasp) A starter kit for building Google Apps Script projects with TypeScript, ESLint, Prettier, Jest and Rollup support out of the box.
 * [apps-script-starter](https://github.com/labnol/apps-script-starter) A starter kit for building Google Apps Script projects with modern JavaScript ES6, Webpack, Babel and ESLint inside Visual Studio Code
 * [realworld-apps-script](https://github.com/lastlink/realworld-apps-script) JWT REST API following the RealWorld API spec
 * [gas-minimal-boilerplate](https://github.com/asciian/gas-minimal-boilerplate) A minimal boilerplate with webpack for Google Apps Script


### PR DESCRIPTION
Added [**ez-clasp**](https://github.com/cristobalgvera/ez-clasp) repository below [starter kits section](https://github.com/contributorpw/google-apps-script-awesome-list#starter-kits) in README.md file.